### PR TITLE
Encoding::UndefinedConversionError: "\xE3" from ASCII-8BIT to UTF-8 に対応

### DIFF
--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -51,6 +51,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     slow_log_data = @client.query('SELECT * FROM slow_log', :cast => false)
 
     slow_log_data.each do |row|
+      row.each_key {|key| row[key].force_encoding(Encoding::ASCII_8BIT) if row[key].is_a?(String)}
       Fluent::Engine.emit(tag, Fluent::Engine.now, row)
     end
 


### PR DESCRIPTION
下記エラーに対応しました。
データが破損して文字コードが正しく認識されなくてもエラーが発生しなくなると思います。
ご確認お願い致します。

<pre>
2014-01-30 16:22:17 +0900 [warn]: emit transaction failed  error_class=Encoding::UndefinedConversionError error=#<Encoding::UndefinedConversionError: "\xE3" from ASCII-8BIT to UTF-8>
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in `encode'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in`to_json'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in `stringify_recor
d'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:112:in`format'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:522:in `block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in`call'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in `each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:513:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:33:in `next'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/buffer.rb:168:in`block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/buffer.rb:164:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:523:in `block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in`call'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in `each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:513:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:33:in `next'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/plugin/out_copy.rb:73:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/match.rb:36:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/engine.rb:151:in`emit_stream'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/engine.rb:131:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:54:in`block in output'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:53:in `each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:53:in`output'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:45:in `watch'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in`encode'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in `to_json'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:82:in`stringify_record'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-mixin-plaintextformatter-0.2.4/lib/fluent/mixin/plaintextformatter.rb:112:in `format'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:522:in`block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in `call'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in`each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:513:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:33:in`next'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/buffer.rb:168:in `block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/1.9.1/monitor.rb:211:in`mon_synchronize'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/buffer.rb:164:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:523:in`block in emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in `call'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/event.rb:54:in`each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:513:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/output.rb:33:in`next'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/plugin/out_copy.rb:73:in `emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/match.rb:36:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/engine.rb:151:in `emit_stream'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluentd-0.10.41/lib/fluent/engine.rb:131:in`emit'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:54:in `block in output'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:53:in`each'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:53:in `output'
  2014-01-30 16:22:17 +0900 [warn]: /usr/lib64/fluent/ruby/lib/ruby/gems/1.9.1/gems/fluent-plugin-rds-slowlog-0.0.4/lib/fluent/plugin/in_rds_slowlog.rb:45:in`watch'
<pre>
