### PR TITLE
Use test unit explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
 
 script: bundle exec rake test

--- a/fluent-plugin-rds-slowlog.gemspec
+++ b/fluent-plugin-rds-slowlog.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", "~> 0.10.30"
   gem.add_dependency "mysql2",  "~> 0.3.11"
   gem.add_development_dependency "rake", ">= 10.0.4"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatibility layer.