### PR TITLE
Support secret param

### DIFF
--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -15,7 +15,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   config_param :host,     :string,  :default => nil
   config_param :port,     :integer, :default => 3306
   config_param :username, :string,  :default => nil
-  config_param :password, :string,  :default => nil
+  config_param :password, :string,  :default => nil, :secret => true
   config_param :interval, :integer, :default => 10
 
   def initialize


### PR DESCRIPTION
In Fluentd 0.12.13 or later supports secret parameters feature.
This feature works as below:

```log
  <source>
    type rds_slowlog
    tag rds-slowlog
    host Hostname
    username Username
    password xxxxxx
  </source>
</ROOT>
```