### PR TITLE
Rotate before select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
 
 script: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 - setting `long_query_time`
 
 ## Overview
-***AWS RDS slow_log*** input plugin.  
+***AWS RDS slow_log*** input plugin.
 
-1. **"SELECT * FROM slow_log"**
-2. **"CALL mysql.rds_rotate_slow_log"**
+1. **"CALL mysql.rds_rotate_slow_log"**
+2. **"SELECT * FROM slow_log_backup"**
 
 every 10 seconds from AWS RDS.
 

--- a/fluent-plugin-rds-slowlog.gemspec
+++ b/fluent-plugin-rds-slowlog.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mysql2",  "~> 0.3.11"
   gem.add_development_dependency "rake", ">= 10.0.4"
+  gem.add_development_dependency "test-unit", "~> 3.1.3"
 end

--- a/fluent-plugin-rds-slowlog.gemspec
+++ b/fluent-plugin-rds-slowlog.gemspec
@@ -14,7 +14,13 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency "fluentd", "~> 0.10.30"
+
+  if RUBY_VERSION >= '1.9.3'
+    gem.add_dependency "fluentd"
+  else
+    gem.add_dependency "fluentd", "<= 0.10.55"
+  end
+
   gem.add_dependency "mysql2",  "~> 0.3.11"
   gem.add_development_dependency "rake", ">= 10.0.4"
 end

--- a/fluent-plugin-rds-slowlog.gemspec
+++ b/fluent-plugin-rds-slowlog.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mysql2",  "~> 0.3.11"
   gem.add_development_dependency "rake", ">= 10.0.4"
   gem.add_development_dependency "test-unit", "~> 3.1.3"
+  gem.add_development_dependency "timecop"
 end

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -16,6 +16,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   config_param :port,     :integer, :default => 3306
   config_param :username, :string,  :default => nil
   config_param :password, :string,  :default => nil
+  config_param :interval, :integer, :default => 10
 
   def initialize
     super
@@ -51,7 +52,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   private
   def watch
     while true
-      sleep 10
+      sleep @interval
       output
     end
   end

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -6,6 +6,11 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     define_method("log") { $log }
   end
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :tag,      :string
   config_param :host,     :string,  :default => nil
   config_param :port,     :integer, :default => 3306
@@ -57,7 +62,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
 
     slow_log_data.each do |row|
       row.each_key {|key| row[key].force_encoding(Encoding::ASCII_8BIT) if row[key].is_a?(String)}
-      Fluent::Engine.emit(tag, Fluent::Engine.now, row)
+      router.emit(tag, Fluent::Engine.now, row)
     end
 
     @client.query('CALL mysql.rds_rotate_slow_log')

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -61,15 +61,15 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   end
 
   def output
+    @client.query('CALL mysql.rds_rotate_slow_log')
+
     slow_log_data = []
-    slow_log_data = @client.query('SELECT * FROM slow_log', :cast => false)
+    slow_log_data = @client.query('SELECT * FROM slow_log_backup', :cast => false)
 
     slow_log_data.each do |row|
       row.each_key {|key| row[key].force_encoding(Encoding::ASCII_8BIT) if row[key].is_a?(String)}
       router.emit(tag, Fluent::Engine.now, row)
     end
-
-    @client.query('CALL mysql.rds_rotate_slow_log')
   end
 
   class TimerWatcher < Coolio::TimerWatcher

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,8 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require "test/unit"
+require "mysql2"
+require "timecop"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -1,8 +1,69 @@
 require 'helper'
 
 class Rds_SlowlogInputTest < Test::Unit::TestCase
+  class << self
+    def startup
+      setup_database
+      Timecop.freeze(Time.parse('2015/05/24 18:30 UTC'))
+    end
+
+    def shutdown
+      cleanup_database
+    end
+
+    def setup_database
+      client = Mysql2::Client.new(:username => 'root')
+      client.query("GRANT ALL ON *.* TO test_rds_user@localhost IDENTIFIED BY 'test_rds_password'")
+      client.query("DROP TABLE IF EXISTS `mysql`.`slow_log`")
+
+      client.query <<-EOS
+        CREATE TABLE `mysql`.`slow_log` (
+          `start_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          `user_host` mediumtext NOT NULL,
+          `query_time` time NOT NULL,
+          `lock_time` time NOT NULL,
+          `rows_sent` int(11) NOT NULL,
+          `rows_examined` int(11) NOT NULL,
+          `db` varchar(512) NOT NULL,
+          `last_insert_id` int(11) NOT NULL,
+          `insert_id` int(11) NOT NULL,
+          `server_id` int(10) unsigned NOT NULL,
+          `sql_text` mediumtext NOT NULL,
+          `thread_id` bigint(21) unsigned NOT NULL
+        ) ENGINE=CSV DEFAULT CHARSET=utf8 COMMENT='Slow log'
+      EOS
+
+      client.query <<-EOS
+        CREATE PROCEDURE `mysql`.`rds_rotate_slow_log`()
+        BEGIN
+          CREATE TABLE IF NOT EXISTS mysql.slow_log2 LIKE mysql.slow_log;
+
+          INSERT INTO `mysql`.`slow_log2` VALUES
+            ('2015-09-29 15:43:44', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 1', 10)
+           ,('2015-09-29 15:43:45', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 2', 11)
+          ;
+
+          DROP TABLE IF EXISTS mysql.slow_log_backup;
+          RENAME TABLE mysql.slow_log TO mysql.slow_log_backup, mysql.slow_log2 TO mysql.slow_log;
+        END
+      EOS
+    end
+
+    def cleanup_database
+      client = Mysql2::Client.new(:username => 'root')
+      client.query("DROP USER test_rds_user@localhost")
+      client.query("DROP PROCEDURE `mysql`.`rds_rotate_slow_log`")
+    end
+  end
+
+  def rotate_slow_log
+    client = Mysql2::Client.new(:username => 'root')
+    client.query("CALL `mysql`.`rds_rotate_slow_log`")
+  end
+
   def setup
     Fluent::Test.setup
+    rotate_slow_log
   end
 
   CONFIG = %[
@@ -10,6 +71,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     host localhost
     username test_rds_user
     password test_rds_password
+    interval 0
   ]
 
   def create_driver(conf = CONFIG)
@@ -22,6 +84,16 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     assert_equal 'localhost', d.instance.host
     assert_equal 'test_rds_user', d.instance.username
     assert_equal 'test_rds_password', d.instance.password
+    assert_equal 0, d.instance.interval
   end
 
+  def test_output
+    d = create_driver
+    d.run
+
+    assert_equal [
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"10"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"11"}],
+    ], d.emits
+  end
 end


### PR DESCRIPTION
It runs `CALL mysql.rds_rotate_slow_log` before the execution of the `SELECT * FROM slow_log`.
This is to prevent to record slow_log after `SELECT * FROM slow_log`.

Also, it was fixed following:

* Add `router` method for label feature 7af5c903589f4ce3cad02f6d59ed41a164941224
* Add New Ruby version to CI 6095a6a37bdcd1ab7d3ea91d75ff602ae244f26b
* Use `Coolio::TimerWatcher` 027b5760efa6ebd105fbcdf4746c73a03c5239ce
* Add `interval` option 040fd9a01225d8938b9b566778b97123e86dc7f1
* Add test case for output method 4056ecd73727412c60e5c47a11ac97441f91072e

Please review PR, and merge If there is no problem. :bow: 

---

`SELECT * FROM slow_log`と`CALL mysql.rds_rotate_slow_log`の間でslow_logテーブルにレコードが追加されるのを懸念して、先に`CALL mysql.rds_rotate_slow_log`を実行してから`SELECT * FROM slow_log_backup`をまたするようにしました。 b6afeb920f4c457015c6d31cb5848c65f3560420

以下の修正も追加しました。

*  `router`メソッドの追加 7af5c903589f4ce3cad02f6d59ed41a164941224
* CIのRubyバージョンの追加 6095a6a37bdcd1ab7d3ea91d75ff602ae244f26b
* `Coolio::TimerWatcher`を利用するにように変更 027b5760efa6ebd105fbcdf4746c73a03c5239ce
* `interval`オプションの追加 040fd9a01225d8938b9b566778b97123e86dc7f1
* テストケースの追加 4056ecd73727412c60e5c47a11ac97441f91072e

レビューをお願いいたします。

