### PR TITLE
Fix test: Add thread_id column check

### DIFF
--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -12,7 +12,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     def setup_database
-      client = Mysql2::Client.new(:username => 'root')
+      client = mysql2_client
       client.query("GRANT ALL ON *.* TO test_rds_user@localhost IDENTIFIED BY 'test_rds_password'")
 
       client.query <<-EOS
@@ -33,7 +33,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     def cleanup_database
-      client = Mysql2::Client.new(:username => 'root')
+      client = mysql2_client
       client.query("DROP USER test_rds_user@localhost")
       client.query("DROP PROCEDURE `mysql`.`rds_rotate_slow_log`")
     end
@@ -61,14 +61,18 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     def has_thread_id?
-      client = Mysql2::Client.new(:username => 'root')
+      client = mysql2_client
       fields = client.query("SHOW FULL FIELDS FROM `mysql`.`slow_log`").map {|r| r['Field'] }
       fields.include?('thread_id')
+    end
+
+    def mysql2_client
+      Mysql2::Client.new(:username => 'root')
     end
   end
 
   def rotate_slow_log
-    client = Mysql2::Client.new(:username => 'root')
+    client = self.class.mysql2_client
     client.query("CALL `mysql`.`rds_rotate_slow_log`")
   end
 

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -107,12 +107,13 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     d.run
     records = d.emits
 
-    # for Travis CI
-    records.each {|r| r[2].delete("thread_id") }
+    unless self.class.has_thread_id?
+      records.each {|r| r[2]["thread_id"] = "0" }
+    end
 
     assert_equal [
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1"}],
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
     ], records
   end
 end


### PR DESCRIPTION
Add `slow_log.thread_id` check, because old version MySQL does not have `slow_log.thread_id` column.

(`slow_log.thread_id` does not exist in MySQL of Travis CI)
