### PR TITLE
Enabled to take a backup of slow_logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 1. **"CALL mysql.rds_rotate_slow_log"**
 2. **"SELECT * FROM slow_log_backup"**
+3. **"INSERT INTO yourdb.slow_log_custom_backup SELECT * FROM slow_log_backup"** (if you want to take a backup)
 
 every 10 seconds from AWS RDS.
 
@@ -26,6 +27,7 @@ every 10 seconds from AWS RDS.
   host [RDS Hostname]
   username [RDS Username]
   password [RDS Password]
+  custom_table [Your Backup Tablename]
 </source>
 ```
 
@@ -39,6 +41,7 @@ every 10 seconds from AWS RDS.
   username [RDS Username]
   password [RDS Password]
   interval 10
+  custom_table [Your Backup Tablename]
 </source>
 
 <match rds-slowlog>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ every 10 seconds from AWS RDS.
   host [RDS Hostname]
   username [RDS Username]
   password [RDS Password]
-  custom_table [Your Backup Tablename]
+  backup_table [Your Backup Tablename]
 </source>
 ```
 
@@ -41,7 +41,7 @@ every 10 seconds from AWS RDS.
   username [RDS Username]
   password [RDS Password]
   interval 10
-  custom_table [Your Backup Tablename]
+  backup_table [Your Backup Tablename]
 </source>
 
 <match rds-slowlog>

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -11,12 +11,13 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     define_method("router") { Fluent::Engine }
   end
 
-  config_param :tag,      :string
-  config_param :host,     :string,  :default => nil
-  config_param :port,     :integer, :default => 3306
-  config_param :username, :string,  :default => nil
-  config_param :password, :string,  :default => nil, :secret => true
-  config_param :interval, :integer, :default => 10
+  config_param :tag,          :string
+  config_param :host,         :string,  :default => nil
+  config_param :port,         :integer, :default => 3306
+  config_param :username,     :string,  :default => nil
+  config_param :password,     :string,  :default => nil, :secret => true
+  config_param :interval,     :integer, :default => 10
+  config_param :custom_table, :string,  :default => nil
 
   def initialize
     super
@@ -69,6 +70,11 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     slow_log_data.each do |row|
       row.each_key {|key| row[key].force_encoding(Encoding::ASCII_8BIT) if row[key].is_a?(String)}
       router.emit(tag, Fluent::Engine.now, row)
+    end
+
+    if @custom_table
+      @client.query("CREATE TABLE IF NOT EXISTS #{@custom_table} LIKE slow_log")
+      @client.query("INSERT INTO #{@custom_table} SELECT * FROM slow_log_backup")
     end
   end
 

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -41,6 +41,10 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
 
   def start
     super
+    if @backup_table
+      @client.query("CREATE TABLE IF NOT EXISTS #{@backup_table} LIKE slow_log")
+    end
+
     @loop = Coolio::Loop.new
     timer = TimerWatcher.new(@interval, true, log, &method(:output))
     @loop.attach(timer)
@@ -73,7 +77,6 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     end
 
     if @backup_table
-      @client.query("CREATE TABLE IF NOT EXISTS #{@backup_table} LIKE slow_log")
       @client.query("INSERT INTO #{@backup_table} SELECT * FROM slow_log_backup")
     end
   end

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -17,7 +17,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   config_param :username,     :string,  :default => nil
   config_param :password,     :string,  :default => nil, :secret => true
   config_param :interval,     :integer, :default => 10
-  config_param :custom_table, :string,  :default => nil
+  config_param :backup_table, :string,  :default => nil
 
   def initialize
     super
@@ -72,9 +72,9 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
       router.emit(tag, Fluent::Engine.now, row)
     end
 
-    if @custom_table
-      @client.query("CREATE TABLE IF NOT EXISTS #{@custom_table} LIKE slow_log")
-      @client.query("INSERT INTO #{@custom_table} SELECT * FROM slow_log_backup")
+    if @backup_table
+      @client.query("CREATE TABLE IF NOT EXISTS #{@backup_table} LIKE slow_log")
+      @client.query("INSERT INTO #{@backup_table} SELECT * FROM slow_log_backup")
     end
   end
 

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -88,7 +88,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     username test_rds_user
     password test_rds_password
     interval 0
-    custom_table mysql.slow_log_custom_backup
+    backup_table mysql.slow_log_custom_backup
   ]
 
   def create_driver(conf = CONFIG)
@@ -102,7 +102,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     assert_equal 'test_rds_user', d.instance.username
     assert_equal 'test_rds_password', d.instance.password
     assert_equal 0, d.instance.interval
-    assert_equal 'mysql.slow_log_custom_backup', d.instance.custom_table
+    assert_equal 'mysql.slow_log_custom_backup', d.instance.backup_table
   end
 
   def test_output


### PR DESCRIPTION
It allows to take a backup of slow_log records before the procedure deletes the records.

I want to use this nice plugin as one only to get records, not to delete records, because using sql queries to the table is useful for quick understanding and survey.

Please review PR, and merge If there is no problem.