### PR TITLE
Added encoding and from_encoding parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ every 10 seconds from AWS RDS.
 </source>
 ```
 
-### Example GET RDS slow_log
+### Example: GET RDS slow_log
 
 ```config
 <source>
@@ -68,3 +68,31 @@ every 10 seconds from AWS RDS.
 2013-06-29 00:32:55 +0900 [error]: fluent-plugin-rds-slowlog: cannot connect RDS
 ```
 
+### Example: Encode output string
+
+Specify the encoding of output string. The default is ASCII-8BIT.
+
+```config
+<source>
+  ...
+  encoding UTF-8
+</source>
+```
+
+- If specify only encoding, the plugin changes string to encoding. This use ruby's [String#force_encoding](https://docs.ruby-lang.org/en/trunk/String.html#method-i-force_encoding)
+
+```config
+<source>
+  ...
+  encoding CP932
+  from_encoding UTF-8
+</source>
+```
+
+- If specify encoding and from_encoding, the plugin tries to encode string from from_encoding to encoding. This uses ruby's [String#encode](https://docs.ruby-lang.org/en/trunk/String.html#method-i-encode)
+
+You can get supported encoding list by typing following command:
+
+```
+$ ruby -e 'p Encoding.name_list.sort'
+```

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -13,10 +13,10 @@ class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
   config_param :password,     :string,  :default => nil, :secret => true
   config_param :interval,     :integer, :default => 10
   config_param :backup_table, :string,  :default => nil
-  # The encoding after conversion of the input.
-  config_param :encoding, :string, default: nil
-  # The encoding of the input.
-  config_param :from_encoding, :string, default: nil
+  config_param :encoding, :string, default: nil,
+               :desc => 'The encoding after conversion of the input.'
+  config_param :from_encoding, :string, default: nil,
+               :desc => 'The encoding of the input.'
 
   def configure_encoding
     unless @encoding

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -20,14 +20,39 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
   config_param :password,     :string,  :default => nil, :secret => true
   config_param :interval,     :integer, :default => 10
   config_param :backup_table, :string,  :default => nil
+  # The encoding after conversion of the input.
+  config_param :encoding, :string, default: nil
+  # The encoding of the input.
+  config_param :from_encoding, :string, default: nil
 
   def initialize
     super
     require 'mysql2'
   end
 
+  def configure_encoding
+    unless @encoding
+      if @from_encoding
+        raise Fluent::ConfigError, "fluent-plugin-rds-slowlog: 'from_encoding' parameter must be specified with 'encoding' parameter."
+      end
+    end
+
+    @encoding = parse_encoding_param(@encoding) if @encoding
+    @from_encoding = parse_encoding_param(@from_encoding) if @from_encoding
+  end
+
+  def parse_encoding_param(encoding_name)
+    begin
+      Encoding.find(encoding_name) if encoding_name
+    rescue ArgumentError => e
+      raise Fluent::ConfigError, e.message
+    end
+  end
+
   def configure(conf)
     super
+    configure_encoding
+
     begin
       @client = create_mysql_client
     rescue
@@ -68,7 +93,7 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
     slow_log_data = @client.query('SELECT * FROM slow_log_backup', :cast => false)
 
     slow_log_data.each do |row|
-      row.each_key {|key| row[key].force_encoding(Encoding::ASCII_8BIT) if row[key].is_a?(String)}
+      row.each_key {|key| transcode(row[key]) if row[key].is_a?(String)}
       router.emit(tag, Fluent::Engine.now, row)
     end
 
@@ -93,6 +118,18 @@ class Fluent::Rds_SlowlogInput < Fluent::Input
       :password => @password,
       :database => 'mysql'
     })
+  end
+
+  def transcode(value)
+    if @encoding
+      if @from_encoding
+        value.encode!(@encoding, @from_encoding)
+      else
+        value.force_encoding(@encoding)
+      end
+    else
+      value.force_encoding(Encoding::ASCII_8BIT)
+    end
   end
 
   class TimerWatcher < Coolio::TimerWatcher

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -176,8 +176,8 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
 
   def test_transcode_with_encoding
     d = create_driver(CONFIG_WITH_ENCODING)
-    d.run
-    records = d.emits
+    d.run(expect_emits: 2)
+    records = d.events
 
     unless self.class.has_thread_id?
       records.each {|r| r[2]["thread_id"] = "0" }
@@ -194,8 +194,8 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
 
   def test_transcode_with_encoding_fromencoding
     d = create_driver(CONFIG_WITH_ENCODING_AND_FROMENCODING)
-    d.run
-    records = d.emits
+    d.run(expect_emits: 2)
+    records = d.events
 
     unless self.class.has_thread_id?
       records.each {|r| r[2]["thread_id"] = "0" }

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'helper'
 
 class Rds_SlowlogInputTest < Test::Unit::TestCase
@@ -47,6 +48,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
           VALUES
             ('2015-09-29 15:43:44', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 1', 0)
            ,('2015-09-29 15:43:45', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 2', 0)
+           ,('2015-09-29 15:43:45', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 3 -- テスト', 0)
           ;
         EOS
       else
@@ -56,6 +58,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
           VALUES
             ('2015-09-29 15:43:44', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 1')
            ,('2015-09-29 15:43:45', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 2')
+           ,('2015-09-29 15:43:45', 'root@localhost', '00:00:00', '00:00:00', 0, 0, 'employees', 0, 0, 1, 'SELECT 3 -- テスト')
           ;
         EOS
       end
@@ -114,9 +117,12 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
       records.each {|r| r[2]["thread_id"] = "0" }
     end
 
+    records.each {|r| assert_equal Encoding::ASCII_8BIT, r[2]['sql_text'].encoding }
+
     assert_equal [
       ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
       ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 3 -- #{"テスト".force_encoding(Encoding::ASCII_8BIT)}", "thread_id"=>"0"}],
     ], records
   end
 
@@ -139,6 +145,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     assert_equal [
       {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"},
       {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"},
+      {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 3 -- #{"テスト".force_encoding(Encoding::ASCII_8BIT)}", "thread_id"=>"0"},
     ], records
   end
 end


### PR DESCRIPTION
In our production environment, to_json errors have occurred after updating td-agent v2.3.5.

```
fluentd.warn.internal.message.ip-10-0-1-218
----------------
[15:30:56] Slack Error: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/activesupport-4.2.8/lib/active_support/core_ext/object/json.rb:34:in `encode' / "\xE4" from ASCII-8BIT to UTF-8
```

This error is when fluent-plugin-slack to_json the output of fluent-plugin-rds-slowlog.
Specifically, in-rds-slowlog outputs ASCII-8BIT encoded character string, but out_slack's to_json expects UTF-8 encoded character string, so it is an error.

- ref. https://github.com/kenjiskywalker/fluent-plugin-rds-slowlog/blob/d2f1d6c0f1dbe80cd8096851ba3a77271d2e1b6e/lib/fluent/plugin/in_rds_slowlog.rb#L71
- ref. https://github.com/sowawa/fluent-plugin-slack/blob/c423f539985c9f401736f4b814a5cec68a5a5f9b/lib/fluent/plugin/slack_client.rb#L118

The direct cause is that the emitted ASCII-8BIT string is not implicitly converted to UTF-8 by current msgpack-ruby, since msgpack-ruby v0.6.0~ is now internally used by updating td-agent (fluentd)

- ref. https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog#L71

Since we confirmed that this problem will be solved by passing UTF-8 to encoding parameter, we made PR.

- ref. https://github.com/fluent/fluentd/pull/889
- ref. https://gist.github.com/tamtam180/29028c011abdd36ae0ef#comment-1466407