### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.4
+  - 2.4.1
 
 script: bundle exec rake test
 before_install: gem update bundler

--- a/fluent-plugin-rds-slowlog.gemspec
+++ b/fluent-plugin-rds-slowlog.gemspec
@@ -15,23 +15,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  if RUBY_VERSION > '2.0.0'
-    gem.add_dependency "fluentd"
-  elsif RUBY_VERSION > '1.9.2'
-    gem.add_dependency "fluentd", "~> 0.12.29"
-  else
-    gem.add_dependency "fluentd", "<= 0.10.55"
-  end
-
-  if RUBY_VERSION <= '2.0.0'
-    gem.add_dependency "json", "< 2"
-  end
-
-  if RUBY_VERSION <= '1.9.2'
-    gem.add_development_dependency "rake", "<= 11"
-  else
-    gem.add_development_dependency "rake", ">= 10.0.4"
-  end
+  gem.add_dependency "fluentd", [">= 0.14.0", "< 2"]
+  gem.add_development_dependency "rake", ">= 10.0.4"
 
   gem.add_dependency "mysql2",  "~> 0.3.11"
   gem.add_development_dependency "test-unit", "~> 3.1.3"

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -5,16 +5,6 @@ class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
 
   helpers :timer
 
-  # To support log_level option implemented by Fluentd v0.10.43
-  unless method_defined?(:log)
-    define_method("log") { $log }
-  end
-
-  # Define `router` method of v0.12 to support v0.10 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   config_param :tag,          :string
   config_param :host,         :string,  :default => nil
   config_param :port,         :integer, :default => 3306

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -1,3 +1,4 @@
+require 'mysql2'
 require 'fluent/plugin/input'
 
 class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
@@ -15,7 +16,6 @@ class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
 
   def initialize
     super
-    require 'mysql2'
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/in_rds_slowlog.rb
+++ b/lib/fluent/plugin/in_rds_slowlog.rb
@@ -14,10 +14,6 @@ class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
   config_param :interval,     :integer, :default => 10
   config_param :backup_table, :string,  :default => nil
 
-  def initialize
-    super
-  end
-
   def configure(conf)
     super
     begin
@@ -34,10 +30,6 @@ class Fluent::Plugin::Rds_SlowlogInput < Fluent::Plugin::Input
     end
 
     timer_execute(:in_rds_slowlog_timer, @interval, &method(:output))
-  end
-
-  def shutdown
-    super
   end
 
   private

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'fluent/test/driver/input'
 
 class Rds_SlowlogInputTest < Test::Unit::TestCase
   class << self
@@ -92,7 +93,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::InputTestDriver.new(Fluent::Rds_SlowlogInput).configure(conf)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::Rds_SlowlogInput).configure(conf)
   end
 
   def test_configure
@@ -107,22 +108,22 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
 
   def test_output
     d = create_driver
-    d.run
-    records = d.emits
+    d.run(expect_emits: 2)
+    records = d.events
 
     unless self.class.has_thread_id?
       records.each {|r| r[2]["thread_id"] = "0" }
     end
 
     assert_equal [
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
     ], records
   end
 
   def test_backup
     d = create_driver
-    d.run
+    d.run(expect_emits: 2)
 
     records = []
     client = self.class.mysql2_client
@@ -137,8 +138,8 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     assert_equal [
-      {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"},
-      {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"},
+      {"start_time"=>"2015-09-29 15:43:44.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"},
+      {"start_time"=>"2015-09-29 15:43:45.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"},
     ], records
   end
 end

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -116,8 +116,8 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     assert_equal [
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
-      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"}],
+      ["rds-slowlog", 1432492200, {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"}],
     ], records
   end
 
@@ -138,8 +138,8 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
     end
 
     assert_equal [
-      {"start_time"=>"2015-09-29 15:43:44.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"},
-      {"start_time"=>"2015-09-29 15:43:45.000000", "user_host"=>"root@localhost", "query_time"=>"00:00:00.000000", "lock_time"=>"00:00:00.000000", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"},
+      {"start_time"=>"2015-09-29 15:43:44", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 1", "thread_id"=>"0"},
+      {"start_time"=>"2015-09-29 15:43:45", "user_host"=>"root@localhost", "query_time"=>"00:00:00", "lock_time"=>"00:00:00", "rows_sent"=>"0", "rows_examined"=>"0", "db"=>"employees", "last_insert_id"=>"0", "insert_id"=>"0", "server_id"=>"1", "sql_text"=>"SELECT 2", "thread_id"=>"0"},
     ], records
   end
 end

--- a/test/plugin/test_in_rds_slowlog.rb
+++ b/test/plugin/test_in_rds_slowlog.rb
@@ -10,6 +10,7 @@ class Rds_SlowlogInputTest < Test::Unit::TestCase
 
     def shutdown
       cleanup_database
+      Timecop.return
     end
 
     def setup_database


### PR DESCRIPTION
I've tried to migrate to use v0.14 Input/Output Plugin API.
This PR contains major update change.
Could you bump up ~~minor~~ major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,